### PR TITLE
Support streamlit >= 1.37

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ key: str = "combobox"
 ```
 <br/>
 
-If true, will call `st.experimental_rerun()` on each search keystroke. If this is set to its default (False), the auto-complete results will always be one keystroke behind. 
+If true, will call `st.rerun()` on each search keystroke. If this is set to its default (False), the auto-complete results will always be one keystroke behind. 
 ```python
 rerun_on_update: bool = False
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setuptools.setup(
     name="st-combobox",
-    version="1.1.1",
+    version="1.2.0",
     author="hoggatt",
     description="Streamlit AutoComplete ComboBox",
     long_description=long_description,
@@ -20,7 +20,7 @@ setuptools.setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "streamlit >= 1.0",
+        "streamlit >= 1.27.0",
     ],
     extras_require={
         "tests": ["wikipedia"],

--- a/st_combobox/__init__.py
+++ b/st_combobox/__init__.py
@@ -88,7 +88,7 @@ def _process_search(
         and searchterm == blank_search_value
         and prev_size == 0
     ):
-        st.experimental_rerun()
+        st.rerun()
 
     # if not reruning, can also call for stopping on update
     if stop_on_update:


### PR DESCRIPTION
Remove `st.experimental_rerun()` to support latest version which deprecates it in favor of `st.rerun()`